### PR TITLE
Fixed an error when there is no item of key.

### DIFF
--- a/Lambda/GameResultProcessing.py
+++ b/Lambda/GameResultProcessing.py
@@ -28,15 +28,15 @@ def lambda_handler(event, context):
         scorediff = parsed['ScoreDiff']
         windiff = parsed['WinDiff']
         losediff = parsed['LoseDiff']
-        ddb_table.update_item(
-            TableName="GomokuPlayerInfo",
-            Key={ 'PlayerName' : playername }, 
-            UpdateExpression="set Score = Score + :score, Win = Win + :win, Lose = Lose + :lose",
+        response = ddb_table.update_item(
+            Key={ 'PlayerName' : playername },
+            UpdateExpression="SET Score = if_not_exists(Score, :basescore) + :score, Win = if_not_exists(Win, :basewin) + :win, Lose = if_not_exists(Lose, :baselose) + :lose",
             ExpressionAttributeValues={
-                ':score': decimal.Decimal(scorediff),
-                ':win': decimal.Decimal(windiff),
-                ':lose': decimal.Decimal(losediff)
-            },
-            ReturnValues="UPDATED_NEW"
+                ':basescore': 0,
+                ':basewin': 0,
+                ':baselose': 0,
+                ':score': scorediff,
+                ':win': windiff,
+                ':lose': losediff
+            }
         )
-        

--- a/Lambda/GameResultProcessing.py
+++ b/Lambda/GameResultProcessing.py
@@ -32,7 +32,7 @@ def lambda_handler(event, context):
             Key={ 'PlayerName' : playername },
             UpdateExpression="SET Score = if_not_exists(Score, :basescore) + :score, Win = if_not_exists(Win, :basewin) + :win, Lose = if_not_exists(Lose, :baselose) + :lose",
             ExpressionAttributeValues={
-                ':basescore': 0,
+                ':basescore': 1000,
                 ':basewin': 0,
                 ':baselose': 0,
                 ':score': scorediff,


### PR DESCRIPTION
DynamoDB update_item makes an error when there is no item with the key to update.
Make the update_item to create new item by using if_not_exits function with base value of 0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
